### PR TITLE
Resign state

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -72,6 +72,11 @@ const (
 )
 
 var (
+	// Orchestrator
+
+	// SignCeremonyPoolSize Maximum number of messages signed in a ceremony
+	SignCeremonyPoolSize = 50
+
 	// EVM
 	EvmContractAbi, _                 = abi.JSON(strings.NewReader(bridge.BridgeMetaData.ABI))
 	UnwrapSigHash                     = crypto.Keccak256Hash([]byte(unwrappedSignatureString))

--- a/common/global_state.go
+++ b/common/global_state.go
@@ -12,6 +12,7 @@ const (
 	KeyGenState    uint8 = 1
 	HaltedState    uint8 = 2
 	EmergencyState uint8 = 3
+	ReSignState    uint8 = 4
 )
 
 type GlobalState struct {
@@ -24,6 +25,8 @@ type GlobalState struct {
 	tokensMap                map[uint32]map[string]string
 	isAffiliateProgramActive map[string]bool
 	affiliateStartingHeight  *big.Int
+	resignNetworkClass       uint32
+	resignNetworkChainId     uint32
 }
 
 func NewGlobalState(state *uint8) *GlobalState {
@@ -152,4 +155,13 @@ func (gs *GlobalState) GetAffiliateStartingHeight() *big.Int {
 		gs.affiliateStartingHeight = big.NewInt(0)
 	}
 	return gs.affiliateStartingHeight
+}
+
+func (gs *GlobalState) GetResignNetwork() (uint32, uint32) {
+	return gs.resignNetworkClass, gs.resignNetworkChainId
+}
+
+func (gs *GlobalState) SetResignNetwork(networkClass, chainId uint32) {
+	gs.resignNetworkClass = networkClass
+	gs.resignNetworkChainId = chainId
 }

--- a/common/types.go
+++ b/common/types.go
@@ -7,6 +7,13 @@ type BridgeMetadata struct {
 	PreParamTimeout  uint64           `json:"preParamTimeout"`
 	JoinPartyVersion string           `json:"joinPartyVersion"`
 	AffiliateProgram AffiliateProgram `json:"affiliateProgram"`
+	ResignState      ResignState      `json:"resignState"`
+}
+
+type ResignState struct {
+	Active       bool   `json:"active"`
+	NetworkClass uint32 `json:"networkClass"`
+	ChainId      uint32 `json:"chainId"`
 }
 
 type AffiliateProgram struct {

--- a/common/types.go
+++ b/common/types.go
@@ -1,13 +1,14 @@
 package common
 
 type BridgeMetadata struct {
-	PartyTimeout     uint64           `json:"partyTimeout"`
-	KeyGenTimeout    uint64           `json:"keyGenTimeout"`
-	KeySignTimeout   uint64           `json:"keySignTimeout"`
-	PreParamTimeout  uint64           `json:"preParamTimeout"`
-	JoinPartyVersion string           `json:"joinPartyVersion"`
-	AffiliateProgram AffiliateProgram `json:"affiliateProgram"`
-	ResignState      ResignState      `json:"resignState"`
+	PartyTimeout         uint64           `json:"partyTimeout"`
+	KeyGenTimeout        uint64           `json:"keyGenTimeout"`
+	KeySignTimeout       uint64           `json:"keySignTimeout"`
+	PreParamTimeout      uint64           `json:"preParamTimeout"`
+	JoinPartyVersion     string           `json:"joinPartyVersion"`
+	AffiliateProgram     AffiliateProgram `json:"affiliateProgram"`
+	ResignState          ResignState      `json:"resignState"`
+	SignCeremonyPoolSize int              `json:"signCeremonyPoolSize"`
 }
 
 type ResignState struct {

--- a/common/utils.go
+++ b/common/utils.go
@@ -79,6 +79,21 @@ func ZnnWrapToOrchestratorWrap(rpcEvent *definition.WrapTokenRequest) events.Wra
 	return ans
 }
 
+func OrchestratorWrapToZnnWrap(rpcEvent *events.WrapRequestZnn) *definition.WrapTokenRequest {
+	ans := &definition.WrapTokenRequest{
+		NetworkClass:           rpcEvent.NetworkClass,
+		ChainId:                rpcEvent.ChainId,
+		Id:                     rpcEvent.Id,
+		ToAddress:              rpcEvent.ToAddress,
+		TokenAddress:           rpcEvent.TokenAddress,
+		Amount:                 big.NewInt(0).Set(rpcEvent.Amount),
+		Fee:                    big.NewInt(0).Set(rpcEvent.Fee),
+		Signature:              rpcEvent.Signature,
+		CreationMomentumHeight: 0,
+	}
+	return ans
+}
+
 func ZnnUnwrapToOrchestatorUnwrap(event *definition.UnwrapTokenRequest) events.UnwrapRequestEvm {
 	var status uint32
 	if event.Revoked == 1 {

--- a/common/utils.go
+++ b/common/utils.go
@@ -140,7 +140,10 @@ func StateToText(state uint8) string {
 		stateStr = "HaltedState"
 	case EmergencyState:
 		stateStr = "EmergencyState"
+	case ReSignState:
+		stateStr = "ReSignState"
 	}
+
 	return stateStr
 }
 

--- a/db/interfaces.go
+++ b/db/interfaces.go
@@ -40,6 +40,7 @@ type ZnnStorage interface {
 	GetWrapRequestById(types.Hash) (*events.WrapRequestZnn, error)
 	GetUnsentSignedWrapRequests() ([]*events.WrapRequestZnn, error)
 	GetUnredeemedWrapRequests() ([]*events.WrapRequestZnn, error)
+	GetResignableWrapRequests() ([]*events.WrapRequestZnn, error)
 
 	GetUnsignedWrapRequests() ([]*events.WrapRequestZnn, error)
 

--- a/db/interfaces.go
+++ b/db/interfaces.go
@@ -36,7 +36,7 @@ type ZnnStorage interface {
 	AddWrapRequest(events.WrapRequestZnn) error
 	SetWrapRequestStatus(types.Hash, uint32) error
 	SetWrapRequestSignature(types.Hash, string) error
-	SetWrapRequestSentSignature(types.Hash) error
+	SetWrapRequestSentSignature(types.Hash, bool) error
 	GetWrapRequestById(types.Hash) (*events.WrapRequestZnn, error)
 	GetUnsentSignedWrapRequests() ([]*events.WrapRequestZnn, error)
 	GetUnredeemedWrapRequests() ([]*events.WrapRequestZnn, error)
@@ -45,4 +45,7 @@ type ZnnStorage interface {
 
 	GetLastUpdateHeight() (uint64, error)
 	SetLastUpdateHeight(uint64) error
+
+	GetResignStatus(types.Hash) (bool, error)
+	SetResignStatus(types.Hash, bool) error
 }

--- a/db/wrap/entries.go
+++ b/db/wrap/entries.go
@@ -2,6 +2,7 @@ package wrap
 
 import (
 	"encoding/binary"
+	"errors"
 	"github.com/syndtr/goleveldb/leveldb"
 	zcommon "github.com/zenon-network/go-zenon/common"
 	"github.com/zenon-network/go-zenon/common/types"
@@ -92,7 +93,7 @@ func (es *eventStore) SetWrapRequestSignature(id types.Hash, signature string) e
 	return nil
 }
 
-func (es *eventStore) SetWrapRequestSentSignature(id types.Hash) error {
+func (es *eventStore) SetWrapRequestSentSignature(id types.Hash, value bool) error {
 	if event, err := es.GetWrapRequestById(id); err != nil {
 		es.SendSigInt()
 		return err
@@ -100,7 +101,7 @@ func (es *eventStore) SetWrapRequestSentSignature(id types.Hash) error {
 		if event == nil {
 			return leveldb.ErrNotFound
 		}
-		event.SentSignature = true
+		event.SentSignature = value
 		if eventBytes, err := event.Serialize(); err != nil {
 			es.SendSigInt()
 			return err
@@ -235,6 +236,42 @@ func (es *eventStore) SetLastUpdateHeight(accBlHeight uint64) error {
 			es.SendSigInt()
 			return err
 		}
+	}
+	return nil
+}
+
+func getResignedStatusKey(id types.Hash) []byte {
+	return zcommon.JoinBytes(resignedStatusPrefix, id.Bytes())
+}
+
+func (es *eventStore) GetResignStatus(id types.Hash) (bool, error) {
+	data, err := es.DB.Get(getResignedStatusKey(id))
+	if errors.Is(err, leveldb.ErrNotFound) {
+		return false, nil
+	}
+
+	if err != nil {
+		es.SendSigInt()
+		return false, err
+	}
+	value := binary.LittleEndian.Uint32(data)
+	ans := false
+	if value > 0 {
+		ans = true
+	}
+	return ans, nil
+}
+
+func (es *eventStore) SetResignStatus(id types.Hash, status bool) error {
+	bytes := make([]byte, 4)
+	value := uint32(0)
+	if status {
+		value = 1
+	}
+	binary.LittleEndian.PutUint32(bytes, value)
+	if err := es.DB.Put(getResignedStatusKey(id), bytes); err != nil {
+		es.SendSigInt()
+		return err
 	}
 	return nil
 }

--- a/db/wrap/keys.go
+++ b/db/wrap/keys.go
@@ -3,6 +3,9 @@ package wrap
 var (
 	wrapEventPrefix = []byte{0}
 
-	// We hold here the account block height on which the orchestrator updated the blocks
+	// We store here the account block height on which the orchestrator updated the blocks
 	lastUpdatePrefix = []byte{1}
+
+	// We store the resigned status on wraps
+	resignedStatusPrefix = []byte{2}
 )

--- a/metadata/version.go
+++ b/metadata/version.go
@@ -1,5 +1,5 @@
 package metadata
 
 const (
-	Version = "v0.0.8"
+	Version = "v0.0.9"
 )

--- a/network/evm.go
+++ b/network/evm.go
@@ -804,3 +804,10 @@ func (eN *evmNetwork) EstimatedBlockTimeRpc() (uint64, error) {
 func (eN *evmNetwork) ConfirmationsToFinalityRpc() (uint64, error) {
 	return eN.EvmRpc().ConfirmationsToFinality()
 }
+
+func (eN *evmNetwork) RedeemsInfo(hash types.Hash) (struct {
+	BlockNumber *big.Int
+	ParamsHash  [32]byte
+}, error) {
+	return eN.EvmRpc().RedeemsInfo(hash)
+}

--- a/network/manager.go
+++ b/network/manager.go
@@ -269,8 +269,20 @@ func (m *NetworksManager) WindowSize() uint64 {
 
 /// Local storage calls
 
-func (m *NetworksManager) SetWrapEventSignature(id types.Hash, signature string) error {
-	return m.znnNetwork.SetWrapEventSignature(id, signature)
+func (m *NetworksManager) SetWrapRequestSignature(id types.Hash, signature string) error {
+	return m.znnNetwork.SetWrapRequestSignature(id, signature)
+}
+
+func (m *NetworksManager) SetWrapRequestSentSignature(id types.Hash, sent bool) error {
+	return m.znnNetwork.SetWrapRequestSentSignature(id, sent)
+}
+
+func (m *NetworksManager) SetResignStatus(id types.Hash, status bool) error {
+	return m.znnNetwork.SetResignStatus(id, status)
+}
+
+func (m *NetworksManager) GetResignStatus(id types.Hash) (bool, error) {
+	return m.znnNetwork.GetResignStatus(id)
 }
 
 func (m *NetworksManager) GetWrapEventById(id types.Hash) (*events.WrapRequestZnn, error) {

--- a/network/manager.go
+++ b/network/manager.go
@@ -269,6 +269,20 @@ func (m *NetworksManager) WindowSize() uint64 {
 
 /// Local storage calls
 
+func (m *NetworksManager) GetResignableWrapRequests() ([]*definition.WrapTokenRequest, error) {
+	wrapRequests, err := m.Znn().GetResignableWrapRequests()
+	if err != nil {
+		return nil, err
+	}
+
+	ans := make([]*definition.WrapTokenRequest, 0)
+	for _, wrap := range wrapRequests {
+		ans = append(ans, common.OrchestratorWrapToZnnWrap(wrap))
+	}
+
+	return ans, nil
+}
+
 func (m *NetworksManager) SetWrapRequestSignature(id types.Hash, signature string) error {
 	return m.znnNetwork.SetWrapRequestSignature(id, signature)
 }
@@ -297,7 +311,7 @@ func (m *NetworksManager) GetUnredeemedWrapRequests() ([]*events.WrapRequestZnn,
 	return m.Znn().GetUnsentSignedWrapRequests()
 }
 
-func (m *NetworksManager) GetUnsignedWrapRequests() ([]*embedded.WrapTokenRequest, error) {
+func (m *NetworksManager) GetUnsignedWrapRequests() ([]*definition.WrapTokenRequest, error) {
 	// todo how many to get for signing?
 	requests, err := m.Znn().GetUnsignedWrapRequestsRpc(0, 100)
 	if err != nil {
@@ -306,10 +320,10 @@ func (m *NetworksManager) GetUnsignedWrapRequests() ([]*embedded.WrapTokenReques
 	if requests == nil || len(requests.List) == 0 {
 		return nil, nil
 	}
-	ans := make([]*embedded.WrapTokenRequest, 0)
+	ans := make([]*definition.WrapTokenRequest, 0)
 	for _, request := range requests.List {
 		if request.ConfirmationsToFinality == 0 {
-			ans = append(ans, request)
+			ans = append(ans, request.WrapTokenRequest)
 		}
 	}
 	return ans, nil

--- a/network/znn.go
+++ b/network/znn.go
@@ -244,7 +244,7 @@ func (rC *znnNetwork) InterpretSendBlockData(sendBlock *api.AccountBlock, live b
 				}
 			}
 			if len(request.Signature) > 0 {
-				if err = rC.eventsStore().SetWrapRequestSentSignature(request.Id); err != nil {
+				if err = rC.eventsStore().SetWrapRequestSentSignature(request.Id, true); err != nil {
 					return err
 				}
 			}
@@ -946,8 +946,20 @@ func (rC *znnNetwork) GetUnredeemedWrapRequests() ([]*events.WrapRequestZnn, err
 	return rC.eventsStore().GetUnredeemedWrapRequests()
 }
 
-func (rC *znnNetwork) SetWrapEventSignature(id types.Hash, signature string) error {
+func (rC *znnNetwork) SetWrapRequestSignature(id types.Hash, signature string) error {
 	return rC.eventsStore().SetWrapRequestSignature(id, signature)
+}
+
+func (rC *znnNetwork) SetWrapRequestSentSignature(id types.Hash, sent bool) error {
+	return rC.eventsStore().SetWrapRequestSentSignature(id, sent)
+}
+
+func (rC *znnNetwork) SetResignStatus(id types.Hash, status bool) error {
+	return rC.eventsStore().SetResignStatus(id, status)
+}
+
+func (rC *znnNetwork) GetResignStatus(id types.Hash) (bool, error) {
+	return rC.eventsStore().GetResignStatus(id)
 }
 
 func (rC *znnNetwork) GetWrapEventById(id types.Hash) (*events.WrapRequestZnn, error) {

--- a/network/znn.go
+++ b/network/znn.go
@@ -942,6 +942,10 @@ func (rC *znnNetwork) GetUnsentSignedWrapRequests() ([]*events.WrapRequestZnn, e
 	return rC.eventsStore().GetUnsentSignedWrapRequests()
 }
 
+func (rC *znnNetwork) GetResignableWrapRequests() ([]*events.WrapRequestZnn, error) {
+	return rC.eventsStore().GetResignableWrapRequests()
+}
+
 func (rC *znnNetwork) GetUnredeemedWrapRequests() ([]*events.WrapRequestZnn, error) {
 	return rC.eventsStore().GetUnredeemedWrapRequests()
 }

--- a/network/znn.go
+++ b/network/znn.go
@@ -243,7 +243,7 @@ func (rC *znnNetwork) InterpretSendBlockData(sendBlock *api.AccountBlock, live b
 					return err
 				}
 			}
-			if len(request.Signature) > 0 {
+			if param.Signature == request.Signature {
 				if err = rC.eventsStore().SetWrapRequestSentSignature(request.Id, true); err != nil {
 					return err
 				}

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -21,6 +21,10 @@ var DefaultNodeConfig = config.Config{
 			Urls:            []string{"ws://127.0.0.1:8545"},
 			FilterQuerySize: 2000,
 		},
+		"Supernova": {
+			Urls:            []string{"wss://rpc.novascan.io"},
+			FilterQuerySize: 2000,
+		},
 	},
 	GlobalState: common.LiveState,
 	TssConfig: config.TssManagerConfig{

--- a/node/node.go
+++ b/node/node.go
@@ -995,16 +995,16 @@ func (node *Node) processSignaturesWrap() (error, bool) {
 	} else if resignableWrapsRequestsIds == nil {
 		resignableWrapsRequestsIds = make([]*definition.WrapTokenRequest, 0)
 	}
-	node.logger.Debugf("Resignable WrapRequests len: %d", len(wrapRequestsIds))
+	node.logger.Debugf("Resignable WrapRequests len: %d", len(resignableWrapsRequestsIds))
 
 	wrapRequestsIds = append(wrapRequestsIds, resignableWrapsRequestsIds...)
 	if len(wrapRequestsIds) == 0 {
 		return nil, false
 	}
+	node.logger.Debugf("Final WrapRequests len: %d", len(wrapRequestsIds))
 
 	messagesToSign := make([][]byte, 0)
 	msgsIndexes := make(map[string]int)
-	node.logger.Debugf("Final WrapRequests len: %d", len(wrapRequestsIds))
 	for idx, request := range wrapRequestsIds {
 		event, err := node.networksManager.GetWrapEventById(request.Id)
 		if err != nil || event == nil {

--- a/node/node.go
+++ b/node/node.go
@@ -1240,6 +1240,8 @@ func (node *Node) sendSignaturesWrap(seenEventsCount map[string]uint32) {
 
 	producerPubKey := base64.StdEncoding.EncodeToString(node.producerKeyPair.Public)
 	for _, req := range requests {
+		node.logger.Debugf("Local wrap: Id: %s, Signature: %s, SentSignature: %v",
+			req.Id.String(), req.Signature, req.SentSignature)
 		rpcRequest, err := node.networksManager.GetWrapRequestByIdRPC(req.Id)
 		if err != nil {
 			node.logger.Debug(err)
@@ -1253,6 +1255,8 @@ func (node *Node) sendSignaturesWrap(seenEventsCount map[string]uint32) {
 			delete(seenEventsCount, req.Id.String())
 			continue
 		}
+		node.logger.Debugf("Rpc wrap: Id: %s, Signature: %s",
+			rpcRequest.Id.String(), rpcRequest.Signature)
 
 		index := uint32(req.Id.Bytes()[31]) % node.getParticipantsLength()
 		if seenEventsCount[req.Id.String()] > 2 {

--- a/node/node.go
+++ b/node/node.go
@@ -1445,10 +1445,15 @@ func (node *Node) SetBridgeMetadata(metadata *common.BridgeMetadata) {
 
 		node.state.SetIsAffiliateProgram(metadata.AffiliateProgram)
 
+		node.logger.Infof("ResignState.Active - new: %v", metadata.ResignState.Active)
 		if metadata.ResignState.Active {
 			if err := node.state.SetState(common.ReSignState); err != nil {
 				node.logger.Debug(err)
 			}
+
+			resignNetworkClass, resignChainId := node.state.GetResignNetwork()
+			node.logger.Infof("ResignState NetworkClass - old: %d, new: %d", resignNetworkClass, metadata.ResignState.NetworkClass)
+			node.logger.Infof("ResignState ChainId - old: %d, new: %d", resignChainId, metadata.ResignState.ChainId)
 			node.state.SetResignNetwork(metadata.ResignState.NetworkClass, metadata.ResignState.ChainId)
 		} else {
 			if err := node.state.SetState(common.LiveState); err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -1110,7 +1110,7 @@ func (node *Node) processSignaturesWrap() (error, bool) {
 			continue
 		}
 
-		if err = node.networksManager.Znn().SetResignStatus(wrapRequestsIds[msgsIndexes[sig.Msg]].Id, true); err != nil {
+		if err = node.networksManager.Znn().SetResignStatus(wrapRequestsIds[msgsIndexes[sig.Msg]].Id, false); err != nil {
 			node.logger.Debug(err)
 			continue
 		}
@@ -1265,7 +1265,7 @@ func (node *Node) sendSignaturesWrap(seenEventsCount map[string]uint32) {
 			node.logger.Info("[sendSignaturesWrap] sent request")
 		}
 		// todo how much to wait between sends?
-		time.Sleep(25 * time.Second)
+		time.Sleep(15 * time.Second)
 	}
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -985,6 +985,18 @@ func (node *Node) processSignaturesWrap() (error, bool) {
 	if err != nil {
 		return err, false
 	} else if wrapRequestsIds == nil {
+		wrapRequestsIds = make([]*definition.WrapTokenRequest, 0)
+	}
+
+	resignableWrapsRequestsIds, err := node.networksManager.GetResignableWrapRequests()
+	if err != nil {
+		return err, false
+	} else if resignableWrapsRequestsIds == nil {
+		resignableWrapsRequestsIds = make([]*definition.WrapTokenRequest, 0)
+	}
+
+	wrapRequestsIds = append(wrapRequestsIds, resignableWrapsRequestsIds...)
+	if len(wrapRequestsIds) == 0 {
 		return nil, false
 	}
 
@@ -996,7 +1008,7 @@ func (node *Node) processSignaturesWrap() (error, bool) {
 		if err != nil || event == nil {
 			// if the rpc returns it but we don't have it locally there was a problem
 			// if we don't have it we just add it now
-			if errStorage := node.networksManager.Znn().AddWrapEvent(request.WrapTokenRequest); errStorage != nil {
+			if errStorage := node.networksManager.Znn().AddWrapEvent(request); errStorage != nil {
 				node.logger.Error(err)
 				node.stopChan <- syscall.SIGINT
 				return err, false

--- a/node/node.go
+++ b/node/node.go
@@ -954,6 +954,7 @@ func (node *Node) processSignatures() {
 								node.logger.Debug(err)
 								continue
 							}
+							node.logger.Debugf("Set wrap %s status as true", wrap.Id.String())
 						} else {
 							status := common.PendingRedeemStatus
 							if redeemStatus.BlockNumber.Cmp(zcommon.BigP256) == 0 {

--- a/node/node.go
+++ b/node/node.go
@@ -1064,7 +1064,11 @@ func (node *Node) processSignaturesWrap() (error, bool) {
 		return nil, false
 	}
 
-	messagesToSign = messagesToSign[:common.SignCeremonyPoolSize]
+	right := len(messagesToSign)
+	if right > common.SignCeremonyPoolSize {
+		right = common.SignCeremonyPoolSize
+	}
+	messagesToSign = messagesToSign[:right]
 	response, err := node.signMessages(messagesToSign, msgsIndexes)
 	if err != nil {
 		return err, true
@@ -1149,7 +1153,13 @@ func (node *Node) processSignaturesUnwrap() (error, bool) {
 	if len(messagesToSign) == 0 {
 		return nil, false
 	}
-	node.logger.Debug("MessagesToSign: ", messagesToSign)
+
+	right := len(messagesToSign)
+	if right > common.SignCeremonyPoolSize {
+		right = common.SignCeremonyPoolSize
+	}
+	messagesToSign = messagesToSign[:right]
+	//node.logger.Debug("MessagesToSign: ", messagesToSign)
 	response, err := node.signMessages(messagesToSign, msgsIndexes)
 	if err != nil {
 		return err, true

--- a/rpc/evm.go
+++ b/rpc/evm.go
@@ -8,6 +8,7 @@ import (
 	etypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/pkg/errors"
+	"github.com/zenon-network/go-zenon/common/types"
 	"github.com/zenon-network/go-zenon/vm/embedded/definition"
 	"github.com/zenon-network/go-zenon/vm/embedded/implementation"
 	"go.uber.org/zap"
@@ -373,6 +374,13 @@ func (r *EvmRpc) EstimatedBlockTime() (uint64, error) {
 
 func (r *EvmRpc) ConfirmationsToFinality() (uint64, error) {
 	return r.bridgeContract.ConfirmationsToFinality(nil)
+}
+
+func (r *EvmRpc) RedeemsInfo(hash types.Hash) (struct {
+	BlockNumber *big.Int
+	ParamsHash  [32]byte
+}, error) {
+	return r.bridgeContract.RedeemsInfo(nil, big.NewInt(0).SetBytes(hash.Bytes()))
 }
 
 func (r *EvmRpc) ContractDeploymentHeight() (uint64, error) {


### PR DESCRIPTION
- mechanism to resign the wraps that have previously been signed with an older tss key and have not been redeemed
- mechanism to set the maximum pool size of messages for a signing ceremony
- set the default Supernova url to the public one
- set new version